### PR TITLE
Add Android Kotlin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# DH_test
-Testing a human design app code
+# HumanDesign App Skeleton
+
+Este repositório contém um esqueleto simples de um aplicativo Android em Kotlin utilizando Jetpack Compose. É inspirado no aplicativo de exemplo "Human Design" citado pelo usuário. O código baseia-se em uma atividade principal que exibe uma saudação.
+
+## Estrutura
+- `settings.gradle` define o projeto principal e inclui o módulo `app`.
+- `build.gradle` configura o plug-in do Android e os repositórios.
+- `app/build.gradle` define as dependências e habilita o Jetpack Compose.
+- `app/src/main/java/com/example/humandesign/MainActivity.kt` contém a atividade inicial.
+
+Para compilar o projeto é necessário ter o Android SDK configurado e executar `gradle build` ou abrir o projeto no Android Studio.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdkVersion 34
+    namespace 'com.example.humandesign'
+
+    defaultConfig {
+        applicationId "com.example.humandesign"
+        minSdkVersion 24
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.0'
+    }
+}
+
+dependencies {
+    implementation "androidx.core:core-ktx:1.12.0"
+    implementation "androidx.activity:activity-compose:1.9.0"
+    implementation "androidx.compose.material3:material3:1.2.0"
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# ProGuard rules for HumanDesign app

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.humandesign">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/humandesign/MainActivity.kt
+++ b/app/src/main/java/com/example/humandesign/MainActivity.kt
@@ -1,0 +1,24 @@
+package com.example.humandesign
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Greeting("Human Design")
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting(name: String) {
+    Text(text = "Bem-vindo ao $name")
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">HumanDesign</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.3.1"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "HumanDesign"
+include(":app")


### PR DESCRIPTION
## Summary
- add simple Android example using Kotlin Compose
- include Gradle build files with Kotlin plugin configuration
- update README with build instructions

## Testing
- `gradle tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6861b9fae0348332acfd309459c7259d